### PR TITLE
Prompt edit

### DIFF
--- a/pyterrier_rag/prompt/_base.py
+++ b/pyterrier_rag/prompt/_base.py
@@ -54,7 +54,7 @@ class PromptTransformer(pt.Transformer):
             self.instruction = prompt(self.instruction)
         if self.model_name_or_path is not None:
             self.conversation_template = (
-                get_conversation_template(self.model_name_or_path) or self.conversation_template
+                self.conversation_template or get_conversation_template(self.model_name_or_path)
             )
         if self.conversation_template is None:
             self.conversation_template = get_conv_template("raw")

--- a/pyterrier_rag/prompt/_base.py
+++ b/pyterrier_rag/prompt/_base.py
@@ -57,8 +57,7 @@ class PromptTransformer(pt.Transformer):
                 self.conversation_template or get_conversation_template(self.model_name_or_path)
             )
         if self.conversation_template is None:
-            self.conversation_template = get_conv_template("raw")
-            self.raw_instruction = True
+            self.conversation_template = get_conv_template("zero-shot")
         if self.system_message is not None:
             # TODO: Set flag for if model supports system message
             self.conversation_template.set_system_message(self.system_message)


### PR DESCRIPTION
Replaces the default templates used in the prompt transformer; the fastchat default is to have a rather long-winded one-shot example, which is unnecessary. Thus, we now use the zero-shot by default.