### PR TITLE
Catch unknown tokenizer for third-party models

### DIFF
--- a/pyterrier_rag/backend/_base.py
+++ b/pyterrier_rag/backend/_base.py
@@ -121,7 +121,7 @@ class Backend(pt.Transformer, ABC):
         raise NotImplementedError("Implement the generate method")
 
     def transform_iter(self, inp: Iterable[dict]) -> Iterable[dict]:
-        return self.text_generator(self).transform_iter(inp)
+        return self.text_generator().transform_iter(inp)
 
 
 class TextBackend(pt.Transformer):

--- a/pyterrier_rag/backend/_openai.py
+++ b/pyterrier_rag/backend/_openai.py
@@ -60,7 +60,10 @@ class OpenAIBackend(Backend):
         if is_tiktoken_availible():
             import tiktoken
 
-            self._tokenizer = tiktoken.encoding_for_model(self._model_name_or_path)
+            try:
+                self._tokenizer = tiktoken.encoding_for_model(self._model_name_or_path)
+            except KeyError:
+                self._tokenizer = None
         else:
             self._tokenizer = None
 


### PR DESCRIPTION
Also piggy-packed a fix where `self` is not needed in the mehtod signature.