### PR TITLE
Backend stopping based on tokens

### DIFF
--- a/pyterrier_rag/backend/_base.py
+++ b/pyterrier_rag/backend/_base.py
@@ -204,6 +204,12 @@ class TextGenerator(pt.Transformer):
         self.batch_size = batch_size
         self.max_new_tokens = max_new_tokens
         self.num_responses = num_responses
+    
+    def transform_inputs(self) -> List[List[str]]:
+        return [[self.input_field]]
+    
+    def transform_outputs(self, inp_cols):
+        return inp_cols + [self.output_field]
 
     def transform_iter(self, inp: pt.model.IterDict) -> pt.model.IterDict:
         for chunk in chunked(inp, self.batch_size):

--- a/pyterrier_rag/backend/_base.py
+++ b/pyterrier_rag/backend/_base.py
@@ -63,6 +63,7 @@ class Backend(pt.Transformer, ABC):
         *,
         return_logprobs: bool = False,
         max_new_tokens: Optional[int] = None,
+        stop_tokens : Optional[List[str]] = None,
     ) -> List[BackendOutput]:
         """ Generate text from input prompts.
 
@@ -70,6 +71,7 @@ class Backend(pt.Transformer, ABC):
             inps (Union[List[str], List[List[dict]]]): Input prompts as strings or dictionaries. When strings, represent the prompts directly. When a list of dictionaries, represents a sequence of messages (if ``backend.supports_message_input==True``).
             return_logprobs (bool): Whether to return logprobs of generated tokens along with text. (Only available if ``backend.supports_logprobs==True``.)
             max_new_tokens (Optional[int]): Override for max tokens to generate.
+            stop_tokens : Optional[List[str]]: List of tokens at which to stop generation. If None, generation is unconstrained.
 
         Returns:
             List[BackendOutput]: An output for each ``inp``, each containing the generated text and optionally logprobs.

--- a/pyterrier_rag/backend/_openai.py
+++ b/pyterrier_rag/backend/_openai.py
@@ -80,6 +80,7 @@ class OpenAIBackend(Backend):
         self,
         prompt: str,
         max_new_tokens: Optional[int] = None,
+        stop_tokens : Optional[List[str]] = None,
         return_logprobs: bool = False,
         num_responses: int = 1,
     ) -> List[BackendOutput]:
@@ -95,6 +96,8 @@ class OpenAIBackend(Backend):
             args['max_tokens'] = max_new_tokens
         if return_logprobs:
             args['logprobs'] = self.logprobs_topk
+        if stop_tokens is not None:
+            args['stop'] = stop_tokens
         try:
             completions = self.client.completions.create(prompt=prompt, **args)
         except Exception as e:
@@ -120,6 +123,7 @@ class OpenAIBackend(Backend):
         max_new_tokens: Optional[int] = None,
         return_logprobs: bool = False,
         num_responses: int = 1,
+        stop_tokens : Optional[List[str]] = None,
     ) -> List[BackendOutput]:
         args = {
             'model': self.model_id,
@@ -132,6 +136,8 @@ class OpenAIBackend(Backend):
         if return_logprobs:
             args['logprobs'] = True
             args['top_logprobs'] = self.logprobs_topk
+        if stop_tokens is not None:
+            args['stop'] = stop_tokens
         try:
             completions = self.client.chat.completions.create(messages=messages, **args)
         except Exception as e:
@@ -157,6 +163,7 @@ class OpenAIBackend(Backend):
         *,
         return_logprobs: bool = False,
         max_new_tokens: Optional[int] = None,
+        stop_tokens : Optional[List[str]] = None,
         num_responses: int = 1,
     ) -> List[BackendOutput]:
         futures = []
@@ -168,6 +175,7 @@ class OpenAIBackend(Backend):
                     max_new_tokens=max_new_tokens,
                     return_logprobs=return_logprobs,
                     num_responses=num_responses,
+                    stop_tokens=stop_tokens
                 ))
         elif self.api == 'chat/completions':
             for inp in inps:
@@ -180,6 +188,7 @@ class OpenAIBackend(Backend):
                     max_new_tokens=max_new_tokens,
                     return_logprobs=return_logprobs,
                     num_responses=num_responses,
+                    stop_tokens=stop_tokens
                 ))
         else:
             raise ValueError(f'api {self.api!r} not supported')

--- a/pyterrier_rag/backend/_vllm.py
+++ b/pyterrier_rag/backend/_vllm.py
@@ -61,6 +61,7 @@ class VLLMBackend(Backend):
         *,
         return_logprobs: bool = False,
         max_new_tokens: Optional[int] = None,
+        stop_tokens : Optional[List[str]] = None,
         num_responses: int = 1,
     ) -> List[BackendOutput]:
         if not isinstance(inps[0], str):
@@ -73,6 +74,8 @@ class VLLMBackend(Backend):
             generation_args['max_tokens'] = max_new_tokens
         if return_logprobs:
             generation_args['logprobs'] = self.logprobs_topk
+        if stop_tokens is not None:
+            generation_args['stop'] = stop_tokens
         args = self.to_params(**generation_args)
         responses = self.model.generate(inps, args)
         text = map(lambda x: x.outputs[0].text, responses)

--- a/pyterrier_rag/frameworks/ir_cot.py
+++ b/pyterrier_rag/frameworks/ir_cot.py
@@ -97,6 +97,12 @@ class IRCOT(pt.Transformer):
             "max_elements": self.max_docs,
             "intermediate_format": ircot_example_format,
         }
+    
+    def transform_inputs(self):
+        return [['qid', 'query']]
+    
+    def transform_outputs(self, inp_cols):
+        return ['qid', 'query', 'qanswer']
 
     @pta.transform.by_query(add_ranks=False)
     def transform_iter(self, inp: Iterable[dict]) -> Iterable[dict]:

--- a/pyterrier_rag/prompt/_base.py
+++ b/pyterrier_rag/prompt/_base.py
@@ -102,6 +102,12 @@ class PromptTransformer(pt.Transformer):
             return instruction
         current_prompt.append_message(self.user_role, instruction)
         return self.to_output(current_prompt)
+    
+    def transform_outputs(self, inp_cols : List[str]) -> List[str]:
+        return [self.output_field, 'qid', 'query_0']
+
+    def transform_inputs(self) -> List[List[str]]:
+        return [self.input_fields]
 
     @pta.transform.by_query(add_ranks=False)
     def transform_iter(self, inp: Iterable[dict]) -> Iterable[dict]:

--- a/pyterrier_rag/prompt/_context_aggregation.py
+++ b/pyterrier_rag/prompt/_context_aggregation.py
@@ -63,6 +63,14 @@ class Concatenator(pt.Transformer):
         self.truncation_rate = truncation_rate
         self.ordering_func = ordering_func
 
+    def transform_inputs(self):
+        if self.in_fields is None:
+            return [['qid', 'query']]
+        return [['qid', 'query'] + self.in_fields]
+
+    def transform_outputs(self, inp_cols):
+        return [self.out_field, 'qid', 'query']
+
     @pta.transform.by_query(add_ranks=False)
     def transform_iter(self, inp: Iterable[dict]) -> Iterable[dict]:
         return self.transform_by_query(inp)

--- a/pyterrier_rag/readers/_base.py
+++ b/pyterrier_rag/readers/_base.py
@@ -52,6 +52,13 @@ class Reader(pt.Transformer):
             else:
                 self.backend = self.backend.text_generator()
 
+    def transform_inputs(self):
+        return pt.inspect.transformer_inputs(self.prompt)
+    
+    def transform_outputs(self, inp_cols):
+        out = pt.inspect.transformer_outputs(self.prompt, inp_cols)
+        return out + [self.output_field]
+
     def transform(self, inp: pd.DataFrame) -> pd.DataFrame:
         prompts = self.prompt(inp)
         outputs = self.backend(prompts)

--- a/pyterrier_rag/readers/_fid_models.py
+++ b/pyterrier_rag/readers/_fid_models.py
@@ -449,6 +449,18 @@ class FiD(pt.Transformer):
         else:
             context = None
         return context
+    
+    def transform_outputs(self, inp_cols : List[str]) -> List[str]:
+        pt.validate.result_frame(inp_cols, extra_columns=[self.text_field])
+        return ["qid", "query", "qanswer"]
+    
+    def transform_inputs(self) -> List[str]:
+        return [
+            ["qid", "query", "docno", self.text_field],
+            ["qid", "query", "docno", self.text_field, "title"], 
+            ["qid", "query", "docno", self.text_field, "score"],
+            ["qid", "query", "docno", self.text_field, "title", "score"],            
+        ]
 
     def format_input_texts(self, question: str, context: Iterable[Union[str, Tuple[str]]]) -> List[str]:
 


### PR DESCRIPTION
Discussion in #41: various agentic models have a need to terminate generation on observing some tokens. This is a simplified version.

Q: I've only altered the generate method - we should perhaps also have the `text_generator()` and (and `logprobs_generator()`?) methods too?