### PR TITLE
fix: use num_responses instead of args.num_responses in error handling

### DIFF
--- a/pyterrier_rag/backend/_openai.py
+++ b/pyterrier_rag/backend/_openai.py
@@ -137,9 +137,9 @@ class OpenAIBackend(Backend):
         except Exception as e:
             print(str(e))
             if "This model's maximum context length is" in str(e):
-                return [BackendOutput(text="ERROR::reduce_length")] * args.num_responses
+                return [BackendOutput(text="ERROR::reduce_length")] * num_responses
             if "The response was filtered" in str(e):
-                return [BackendOutput(text="ERROR::response_filtered")] * args.num_responses
+                return [BackendOutput(text="ERROR::response_filtered")] * num_responses
             return [BackendOutput(text="ERROR::other")] * num_responses
         results = []
         for choice in completions.choices[:num_responses]:


### PR DESCRIPTION
This PR fixes an exception below. `args.num_responses` is not available in the context; it might be `args.n`, but `num_responses` is more resilient and used in other places around.

```python
Traceback (most recent call last):
  File "myenv/lib/python3.12/site-packages/pyterrier_rag/backend/_openai.py", line 136, in _call_chat_completion
    completions = self.client.chat.completions.create(messages=messages, **args)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "myenv/lib/python3.12/site-packages/openai/_utils/_utils.py", line 286, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "myenv/lib/python3.12/site-packages/openai/resources/chat/completions/completions.py", line 1147, in create
    return self._post(
           ^^^^^^^^^^^
  File "myenv/lib/python3.12/site-packages/openai/_base_client.py", line 1259, in post
    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "myenv/lib/python3.12/site-packages/openai/_base_client.py", line 1047, in request
    raise self._make_status_error_from_response(err.response) from None
openai.InternalServerError: Error code: 500 - {'details': "The response was filtered due to the prompt triggering Azure OpenAI's content management policy. Please modify your prompt and retry. To learn more about our content filtering policies please read our documentation: https://go.microsoft.com/fwlink/?linkid=2198766"}

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "evaluate_rag.py", line 115, in main
    results = pt.Experiment(
              ^^^^^^^^^^^^^^
  File "myenv/lib/python3.12/site-packages/pyterrier/pipelines.py", line 650, in Experiment
    time, evalMeasuresDict = _run_and_evaluate(
                             ^^^^^^^^^^^^^^^^^^
  File "myenv/lib/python3.12/site-packages/pyterrier/pipelines.py", line 347, in _run_and_evaluate
    res = system.transform(topics)
          ^^^^^^^^^^^^^^^^^^^^^^^^
  File "myenv/lib/python3.12/site-packages/pyterrier/_ops.py", line 389, in transform
    out = m.transform(out)
          ^^^^^^^^^^^^^^^^
  File "myenv/lib/python3.12/site-packages/pyterrier_rag/readers/_base.py", line 57, in transform
    outputs = self.backend(prompts)
              ^^^^^^^^^^^^^^^^^^^^^
  File "myenv/lib/python3.12/site-packages/pyterrier/transformer.py", line 153, in __call__
    return self.transform(inp)
           ^^^^^^^^^^^^^^^^^^^
  File "myenv/lib/python3.12/site-packages/pyterrier/transformer.py", line 112, in transform
    return pd.DataFrame(list(self.transform_iter(inp.to_dict(orient='records'))))
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "myenv/lib/python3.12/site-packages/pyterrier_rag/backend/_base.py", line 212, in transform_iter
    out = self.backend.generate(
          ^^^^^^^^^^^^^^^^^^^^^^
  File "myenv/lib/python3.12/site-packages/pyterrier_rag/backend/_openai.py", line 188, in generate
    results.extend(r.result())
                   ^^^^^^^^^^
  File "myenv/lib/python3.12/concurrent/futures/_base.py", line 456, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "myenv/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "myenv/lib/python3.12/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "myenv/lib/python3.12/site-packages/pyterrier_rag/backend/_openai.py", line 142, in _call_chat_completion
    return [BackendOutput(text="ERROR::response_filtered")] * args.num_responses
                                                              ^^^^^^^^^^^^^^^^^^
AttributeError: 'dict' object has no attribute 'num_responses'
```