### PR TITLE
infra: isolate requirements and framework export updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ ENV/
 
 
 examples/*/*_index
+.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,4 @@ ENV/
 # Misc
 .DS_Store
 
-
 examples/*/*_index
-.claude/settings.local.json

--- a/examples/nq/sparse_retrieval_FiD_FlanT5.ipynb
+++ b/examples/nq/sparse_retrieval_FiD_FlanT5.ipynb
@@ -64,8 +64,8 @@
    "outputs": [],
    "source": [
     "import pyterrier as pt\n",
-    "pt.utils.set_tqdm('notebook')\n",
-    "import pyterrier_rag"
+    "import pyterrier_rag\n",
+    "pt.utils.set_tqdm('notebook')"
    ]
   },
   {

--- a/examples/nq/sparse_retrieval_llama-api.ipynb
+++ b/examples/nq/sparse_retrieval_llama-api.ipynb
@@ -64,8 +64,8 @@
    "outputs": [],
    "source": [
     "import pyterrier as pt\n",
-    "pt.utils.set_tqdm('notebook')\n",
-    "import pyterrier_rag"
+    "import pyterrier_rag\n",
+    "pt.utils.set_tqdm('notebook')"
    ]
   },
   {
@@ -302,7 +302,7 @@
     "from pyterrier_rag.backend import OpenAIBackend\n",
     "from pyterrier_rag.prompt import Concatenator\n",
     "from pyterrier_rag.readers import Reader\n",
-    "from pyterrier_rag.prompt import PromptTransformer, prompt\n",
+    "from pyterrier_rag.prompt import PromptTransformer\n",
     "\n",
     "from fastchat.model import get_conversation_template"
    ]

--- a/examples/r1searcher.ipynb
+++ b/examples/r1searcher.ipynb
@@ -918,8 +918,8 @@
     }
    ],
    "source": [
-    "dataset = pt.get_dataset('rag:nq')\n",
     "from ir_measures import define_byquery\n",
+    "dataset = pt.get_dataset('rag:nq')\n",
     "Iterations = define_byquery(lambda qrels, run: run.iloc[0].iteration, name=\"Iterations\")\n",
     "pt.Experiment(\n",
     "    [searcherR1],\n",
@@ -1014,8 +1014,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset = pt.get_dataset('rag:nq')\n",
     "from ir_measures import define_byquery\n",
+    "dataset = pt.get_dataset('rag:nq')\n",
     "Iterations = define_byquery(lambda qrels, run: run.iloc[0].iteration, name=\"Iterations\")\n",
     "pt.Experiment(\n",
     "    [searcherR1_e5],\n",

--- a/examples/search-o1.ipynb
+++ b/examples/search-o1.ipynb
@@ -90,8 +90,6 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "import pyterrier_rag\n",
-        "\n",
         "\n",
         "model_args = {\"torch_dtype\": torch.bfloat16, \"trust_remote_code\": True}\n",
         "generator = pyterrier_rag.backend.HuggingFaceBackend(\n",
@@ -507,8 +505,8 @@
         }
       ],
       "source": [
-        "dataset = pt.get_dataset('rag:nq')\n",
         "from ir_measures import define_byquery\n",
+        "dataset = pt.get_dataset('rag:nq')\n",
         "Iterations = define_byquery(lambda qrels, run: run.iloc[0].search_count if \"search_count\" in run.columns else 0, name=\"Iterations\")\n",
         "pt.Experiment(\n",
         "    [o1_bm25, o1_monoT5],\n",

--- a/examples/search-r1.ipynb
+++ b/examples/search-r1.ipynb
@@ -433,8 +433,8 @@
         }
       ],
       "source": [
-        "dataset = pt.get_dataset('rag:nq')\n",
         "from ir_measures import define_byquery\n",
+        "dataset = pt.get_dataset('rag:nq')\n",
         "Iterations = define_byquery(lambda qrels, run: run.iloc[0].iteration, name=\"Iterations\")\n",
         "pt.Experiment(\n",
         "    [r1_bm25, r1_monoT5],\n",

--- a/pyterrier_rag/frameworks/__init__.py
+++ b/pyterrier_rag/frameworks/__init__.py
@@ -1,6 +1,10 @@
 from .ir_cot import IRCOT
 from .llm_as_judge import LLMasJudge
-from .kg_rag.kg_extractor import KnowledgeGraphExtractor 
-from .kg_rag.kg_reasoning import ReasoningChainGenerator 
+try:
+    from .kg_rag.kg_extractor import KnowledgeGraphExtractor
+    from .kg_rag.kg_reasoning import ReasoningChainGenerator
+except ImportError:
+    KnowledgeGraphExtractor = None
+    ReasoningChainGenerator = None
 
 __all__ = ["IRCOT", "LLMasJudge", "KnowledgeGraphExtractor", "ReasoningChainGenerator"]

--- a/pyterrier_rag/frameworks/__init__.py
+++ b/pyterrier_rag/frameworks/__init__.py
@@ -1,10 +1,6 @@
 from .ir_cot import IRCOT
 from .llm_as_judge import LLMasJudge
-try:
-    from .kg_rag.kg_extractor import KnowledgeGraphExtractor
-    from .kg_rag.kg_reasoning import ReasoningChainGenerator
-except ImportError:
-    KnowledgeGraphExtractor = None
-    ReasoningChainGenerator = None
+from .kg_rag.kg_extractor import KnowledgeGraphExtractor
+from .kg_rag.kg_reasoning import ReasoningChainGenerator
 
 __all__ = ["IRCOT", "LLMasJudge", "KnowledgeGraphExtractor", "ReasoningChainGenerator"]

--- a/pyterrier_rag/readers/_fid_models.py
+++ b/pyterrier_rag/readers/_fid_models.py
@@ -471,14 +471,17 @@ class FiD(pt.Transformer):
         return input_texts
 
     def tokenizer_encode(self, texts: List[str]) -> Dict[str, torch.Tensor]:
-
-        tokenizer_outputs = self.tokenizer.batch_encode_plus(
-            texts,
-            max_length = self.text_max_length,
-            padding = "max_length",
-            truncation = True,
-            return_tensors = 'pt'
+        encode_kwargs = dict(
+            max_length=self.text_max_length,
+            padding="max_length",
+            truncation=True,
+            return_tensors="pt",
         )
+        # Newer tokenizers are directly callable; keep a legacy fallback.
+        try:
+            tokenizer_outputs = self.tokenizer(texts, **encode_kwargs)
+        except TypeError:
+            tokenizer_outputs = self.tokenizer.batch_encode_plus(texts, **encode_kwargs)
         input_ids = tokenizer_outputs["input_ids"][None, :, :] # for only one query
         attention_mask = tokenizer_outputs["attention_mask"][None, :, :]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-terrier>=0.13.0
+pyterrier
 pyterrier_alpha>=0.12.0
 ir_measures>=0.4.1
 regex

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyterrier
+pyterrier>=1.0
 pyterrier_alpha>=0.12.0
 ir_measures>=0.4.1
 regex


### PR DESCRIPTION
## Summary
- isolate infra-only changes from the prompt-refactor series
- switch requirements to `pyterrier`
- update FiD tokenizer call to support modern callable tokenizers with fallback to `batch_encode_plus`
